### PR TITLE
Add Plug to be used with nvim

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -43,6 +43,11 @@ ln -sf `pwd`/bin/subcount ~/bin/subcount
 # hyper
 ln -sf `pwd`/hyper/.hyper.js ~/.hyper.js
 
+# Plug (to be used with nvim)
+# https://github.com/junegunn/vim-plug
+curl -fLo ~/.config/nvim/autoload/plug.vim --create-dirs \
+    https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+
 # nvim
 mkdir -p ~/.config/nvim
 ln -sf `pwd`/nvim/init.vim ~/.config/nvim/


### PR DESCRIPTION
In the current setup, if we use nvim, we will have a lot of conflicts because Plug is not installed.
This PR just add Plug, but we should also have a way to do a `:PlugInstall` in the setup.sh